### PR TITLE
make getEngineProperties() public

### DIFF
--- a/src/CloudRequestEngine.php
+++ b/src/CloudRequestEngine.php
@@ -266,23 +266,6 @@ class CloudRequestEngine extends Engine
     }
 
     /**
-     * Internal function for getting evidence keys used by cloud engines.
-     *
-     * @return array<string> List of keys
-     */
-    private function getEvidenceKeys(): array
-    {
-        $evidenceKeyRequest = $this->httpClient->makeCloudRequest(
-            'GET',
-            $this->baseURL . 'evidencekeys',
-            null,
-            $this->cloudRequestOrigin
-        );
-
-        return json_decode($evidenceKeyRequest, true);
-    }
-
-    /**
      * Get properties for cloud engines from the cloud service.
      *
      * @return array<string, string|array<string, array<string, bool|string>>>
@@ -319,11 +302,28 @@ class CloudRequestEngine extends Engine
     }
 
     /**
+     * Internal function for getting evidence keys used by cloud engines.
+     *
+     * @return array<string> List of keys
+     */
+    private function getEvidenceKeys(): array
+    {
+        $evidenceKeyRequest = $this->httpClient->makeCloudRequest(
+            'GET',
+            $this->baseURL . 'evidencekeys',
+            null,
+            $this->cloudRequestOrigin
+        );
+
+        return json_decode($evidenceKeyRequest, true);
+    }
+
+    /**
      * Internal helper method to lowercase keys returned from the
      * cloud service.
      *
-     * @param array<int|string, string|array<string, mixed>> $arr
-     * @return array<int|string, string|array<string, mixed>>
+     * @param array<int|string, array<string, mixed>|string> $arr
+     * @return array<int|string, array<string, mixed>|string>
      */
     private function lowerCaseArrayKeys(array $arr): array
     {

--- a/src/CloudRequestEngine.php
+++ b/src/CloudRequestEngine.php
@@ -283,11 +283,11 @@ class CloudRequestEngine extends Engine
     }
 
     /**
-     * Internal method to get properties for cloud engines from the cloud service.
+     * Get properties for cloud engines from the cloud service.
      *
      * @return array<string, string|array<string, array<string, bool|string>>>
      */
-    private function getEngineProperties(): array
+    public function getEngineProperties(): array
     {
         // Get properties for all engines
 
@@ -312,6 +312,8 @@ class CloudRequestEngine extends Engine
                 $flowElementProperties[$dataKey][strtolower($meta['name'])] = $meta;
             }
         }
+
+        $this->flowElementProperties = $flowElementProperties;
 
         return $flowElementProperties;
     }

--- a/tests/CloudResponse.php
+++ b/tests/CloudResponse.php
@@ -95,6 +95,32 @@ class CloudResponse extends CloudRequestEngineTestsBase
     }
 
     /**
+     * Verify that getEngineProperties() can be called directly
+     * (without processInternal()) and that it both returns the
+     * expected engines and populates $engine->flowElementProperties.
+     */
+    public function testGetEnginePropertiesEager()
+    {
+        $engine = new CloudRequestEngine([
+            'resourceKey' => 'subpropertieskey',
+            'httpClient' => $this->mockHttp()
+        ]);
+
+        // flowElementProperties should be empty before any call
+        $this->assertEmpty($engine->flowElementProperties);
+
+        $result = $engine->getEngineProperties();
+
+        // Return value should contain expected engines
+        $this->assertArrayHasKey('device', $result);
+        $this->assertArrayHasKey('devices', $result);
+
+        // flowElementProperties should now also be populated
+        $this->assertEquals($result, $engine->flowElementProperties);
+        $this->assertEquals(2, count($engine->flowElementProperties));
+    }
+
+    /**
      * Test cloud request engine handles errors from the cloud service
      * as expected.
      * An exception should be thrown by the cloud request engine


### PR DESCRIPTION
Make getEngineProperties() public to be able to call eagerly (needed for pipeline-wordpress)