### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,5 +4,5 @@ This API complies with the `common-ci` approach.
 The following secrets are required:
 * `ACCESS_TOKEN` - GitHub [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#about-personal-access-tokens) for cloning repos, creating PRs, etc.
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
-* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/4.4/_info__resource_keys.html) for integration tests
+* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-php-cloudrequestengine&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for integration tests
     * Example: `R4nd0m-S7r1ng`

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # 51Degrees PHP Cloud Request Engine
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=php-open-source "Data rewards the curious") **PHP Pipeline API**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-php-cloudrequestengine&utm_content=readme.md&utm_term=51degrees-php-cloud-request-engine "Data rewards the curious") **PHP Pipeline API**
 
-[Developer Documentation](https://51degrees.com/documentation/4.2/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=php-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/documentation/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-php-cloudrequestengine&utm_content=readme.md&utm_term=51degrees-php-cloud-request-engine "developer documentation")
 
 ## Introduction
 This project contains the source code for the CloudrequestEngine for the PHP implementation of the 51Degrees Pipeline API.


### PR DESCRIPTION
Apply the standard UTM vocabulary to navigational 51degrees.com links so the Content Team can trace traffic to its exact source.

Changes:
- readme.md: replaced legacy Logo.ashx logo URL with /img/logo.png, retagged logo and developer documentation links (old php-open-source scheme), un-versioned the 4.2 documentation path.
- ci/README.md: tagged the resource-key documentation link, un-versioned the 4.4 documentation path.
- Added .github/workflows/utm-link-lint.yml.

Functional hosts (cloud.51degrees.com), the engineering email, and test fixtures were left untouched. composer.json has no homepage field. Lint passes with scripts/utm-lint.ps1.